### PR TITLE
Remove dollar sign in favor of getElementsByClassName

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,8 +1,8 @@
 module.exports = (Franz) => {
   const getUnreads = () => {
-    const e = $('.badge--notification');
-		if (e) {
-			Franz.setBadge(Number(e.text()));
+    const e = document.getElementsByClassName('badge--notification');
+		if (e && e.length > 0) {
+			Franz.setBadge(Number(e[0].text()));
 		} else {
 			Franz.setBadge(0)
 		}

--- a/webview.js
+++ b/webview.js
@@ -2,7 +2,7 @@ module.exports = (Franz) => {
   const getUnreads = () => {
     const e = document.getElementsByClassName('badge--notification');
 		if (e && e.length > 0) {
-			Franz.setBadge(Number(e[0].text()));
+			Franz.setBadge(Number(e[0].innerText));
 		} else {
 			Franz.setBadge(0)
 		}


### PR DESCRIPTION
Removed `$` because Nulab account page doesn't have jQuery.